### PR TITLE
Update DAKeyboardControl.m

### DIFF
--- a/DAKeyboardControl/DAKeyboardControl.m
+++ b/DAKeyboardControl/DAKeyboardControl.m
@@ -275,7 +275,16 @@ static char UIViewKeyboardOpened;
 
 - (void)inputKeyboardDidShow
 {
-    // Grab the keyboard view
+    // Grab the keyboard view if we have access to it
+    if ([self.keyboardActiveInput respondsToSelector:@selector(inputAccessoryView)]) {
+        self.keyboardActiveView = self.keyboardActiveInput.inputAccessoryView.superview;
+    }
+    
+    // get out of dodge if we couldn't get the instance
+    if (!self.keyboardActiveView) {
+        return;
+    }
+
     self.keyboardActiveView = self.keyboardActiveInput.inputAccessoryView.superview;
     self.keyboardActiveView.hidden = NO;
     


### PR DESCRIPTION
Fixes an issue where we attempt to get self.keyboardACtiveInput.inputAccessoryView, but the target doesn't respond to this request, resulting in a crash. A good example of this is when you present an `MFMailComposeViewController`; crash only occurs on first launch of the app.
